### PR TITLE
Adding global config to allow isis add commit to pass successfully

### DIFF
--- a/ISIS/nc-isis-add.py
+++ b/ISIS/nc-isis-add.py
@@ -31,6 +31,11 @@ isis = """
       </name>
      </config>
      <isis>
+      <global>
+        <config>
+          <instance>SUPERCORE</instance>
+        </config>
+      </global>
       <interfaces>
        <interface>
         <interface-id>
@@ -236,7 +241,7 @@ isis = """
 </config>
 """
 
-configuration = eos.edit_config(target = "running", config = isis, default_operation="merge")
+configuration = eos.edit_config(target="running", config=isis, default_operation="merge")
 print(configuration)
 
 eos.close_session()


### PR DESCRIPTION
When running the example arista_eos_automation_with_ncclient/ISIS/nc-isis-add.py I get a failure message of ncclient.operations.rpc.RPCError: instance name 0 @ network-instances/network-instance/protocols/protocol/isis/global/config different than protocol name SUPERCORE @ network-instances/network-instance/protocols/protocol

Running virtual EOS version: Software image version: 4.26.2F

Added the following to the isis config:
```xml
      <global>
        <config>
          <instance>SUPERCORE</instance>
        </config>
      </global>
```
Also removed whitespace. 